### PR TITLE
Add docker build and publish on push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: docker
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: CI
+name: docker
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOCKER_PUBLISH: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Disable docker publishing if in PR build
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "Docker publishing in PR is disabled"
+        env: 
+          DOCKER_PUBLISH: false  
+      
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ env.DOCKER_PUBLISH }}
+          tags: okmo/renode:latest
+          cache-from: type=registry,ref=okmo/renode:renodecache
+          cache-to: type=registry,ref=okmo/renode:renodecache,mode=max
+
+      - name: Build and push min renode image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.min
+          push: ${{ env.DOCKER_PUBLISH }}
+          tags: okmo/renodemin:latest
+          cache-from: type=registry,ref=okmo/renodemin:renodemincache
+          cache-to: type=registry,ref=okmo/renodemin:renodemincache,mode=max


### PR DESCRIPTION
Build renode and renode min images. Publish if not in PR.

You can find the build at
https://github.com/ok-mo/renode-docker/actions/runs/3556733430/jobs/5974307578
and the images at 
https://hub.docker.com/r/okmo/renode/tags
https://hub.docker.com/r/okmo/renodemin/tags

Todo:
- change okmo to renode where necessary
- add secrets for renode

closes https://github.com/renode/renode/issues/372