### PR TITLE
Bump to version 1.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER developer
 ENV HOME /home/developer
 WORKDIR /home/developer
 
-ARG RENODE_VERSION=1.15.3
+ARG RENODE_VERSION=1.16.0
 
 # Install Renode
 USER root

--- a/Dockerfile.min
+++ b/Dockerfile.min
@@ -3,7 +3,7 @@
 #      GLOBAL ARGS      #
 #########################
 ARG RENODE_DEST_BUILDER=/opt/renode/
-ARG RENODE_VERSION=1.15.3
+ARG RENODE_VERSION=1.16.0
 ARG RENODE_URL=https://github.com/renode/renode/releases/download/v$RENODE_VERSION/renode-$RENODE_VERSION.linux-portable.tar.gz
 
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Renode minimized container image
 ================================
 
 This Dockerfile uses a multistage build with runtime image based on mono:slim to minimize runtime container components and static image size.
-By default if no version is passed via `--build-arg RENODE_VERSION=x.y.z` it will build `1.15.3`.
+By default if no version is passed via `--build-arg RENODE_VERSION=x.y.z` it will build `1.16.0`.
 
 Note on ``Podman`` replacing ``Docker``: https://podman.io/whatis.html
 
@@ -48,7 +48,7 @@ Connect to the running interactive instance of Renode
 Build a specific version of Renode
 ----------------------------------
 
-``podman build -t renode_min_test ./ -f Dockerfile.min --build-arg RENODE_VERSION=1.15.3``
+``podman build -t renode_min_test ./ -f Dockerfile.min --build-arg RENODE_VERSION=1.16.0``
 
 For more information, visit the `Renode website <https://renode.io>`_, `Renode documentation <https://renode.readthedocs.io>`_ and `Docker documentation <https://docs.docker.com>`_.
 


### PR DESCRIPTION
Bump to [v16](https://github.com/renode/renode/releases/tag/v1.16.0)